### PR TITLE
Adding dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+*
+!src
+!lib
+!misc
+!include
+!test
+!degraded_audio_tests
+!wav_analyzer
+!Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:latest
+
+# These commands copy your files into the specified directory in the image
+# and set that as the working location
+COPY . /usr/src/pitch-detection
+WORKDIR /usr/src/pitch-detection
+
+# Install dependencies from apt
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+git \
+cmake \
+gcc \
+g++ \
+libblas-dev \
+liblapack-dev \
+libboost-dev \
+libarmadillo-dev \
+libmlpack-dev \
+libgtest-dev \
+libbenchmark-dev
+
+# Get and install ffts library
+RUN cd /usr/src \
+&& git clone https://github.com/anthonix/ffts.git ffts-repo \
+&& cd ffts-repo \
+&& mkdir build \
+&& cd build \
+&& cmake .. \
+&& make install
+
+# Build and install the pitch-detection library, as well as the tests and benchmarks
+RUN cd /usr/src/pitch-detection && make clean all && make -C test clean all && make install
+
+LABEL Name=pitch-detection Version=0.0.1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This project depends on [ffts](https://github.com/anthonix/ffts), BLAS/LAPACK, a
 
 Build and install pitch_detection, run the tests, and build the sample application, wav_analyzer:
 
-```
+```bash
 # build libpitch_detection.so
 make clean all
 
@@ -63,6 +63,42 @@ sudo make install
 # build and run C++ sample
 make -C wav_analyzer clean all
 ./wav_analyzer/wav_analyzer
+```
+
+#### Docker image
+
+To allow running and prototyping on unsupported operating systems, there's a [Dockerfile](./Dockerfile) that sets up a Linux container with all the dependencies for compiling the library and running the included tests and benchmarks.
+
+To build the image, make sure you have installed and setup [Docker](https://docs.docker.com/get-started/) on your computer. After following the setup instructions, run the following command from the cloned repository root: 
+
+```bash
+docker build --rm --pull -f "Dockerfile" -t pitchdetection:latest "."
+```
+
+The `--rm` flag specifies that the intermediate containers will be removed after the build is complete. This just cleans up space on your system. The `--pull` flag specifies that the base image ([ubuntu](https://hub.docker.com/_/ubuntu/?tab=description):latest) will be pulled from Docker Hub if it is available.
+
+Once you've built your image (which should take about 20 minutes), you can run the image in a new container using the following command:
+
+```bash
+docker run --rm --init -it pitchdetection:latest
+```
+
+The `--rm` flag here specifies that Docker should remove the container after you exit the shell. If this is not desired you can remove this. The `--init` flag solves a common problem with Docker containers that you can read more about [here](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/). The `-it` flags specify that Docker should create the Container with a shell and enter into it, allowing you to start sending commands to the container right away.
+
+Your container is now set up. You can run the following commands to to confirm that everything is working properly:
+
+```bash
+./test/test
+./test/bench
+```
+
+A pre-compiled image can be found at [esimkowitz/pitchdetection](https://hub.docker.com/repository/docker/esimkowitz/pitchdetection).
+
+To use this, rather than building and running the image as described above, run the following commands:
+
+```bash
+docker pull esimkowitz/pitchdetection:latest
+docker run --rm --init -it esimkowitz/pitchdetection:latest
 ```
 
 ### Usage


### PR DESCRIPTION
I've written a dockerfile to build and run your pitch-detection code. As it's set up right now, it builds the code and its dependencies, as well as the test and benchmark programs. 

One thing I noticed is that with the latest libraries from APT, the following four tests are failing. Is this a known issue? If so, do you know which versions of which libraries are stable with the code?
* PYinInstrumentTest.Piano_D4_44100
```
./test_instruments.cpp:157: Failure
The difference between expected and pitch is 568.59766233715936, which exceeds 0.01 * expected, where
expected evaluates to 293.69999999999999,
pitch evaluates to 862.2976623371593, and
0.01 * expected evaluates to 2.9369999999999998.
```
* PYinInstrumentTest.Acoustic_E2_44100
```
./test_instruments.cpp:166: Failure
The difference between expected and pitch is 82.858104120934797, which exceeds 0.01 * expected, where
expected evaluates to 82.409999999999997,
pitch evaluates to 165.26810412093479, and
0.01 * expected evaluates to 0.82409999999999994.
```
* MpmEdgeCase.InvalidAlloc
```
./test_edge_cases.cpp:18: Failure
Expected: pitch_alloc::Mpm<double> ma(-1) throws an exception of type std::bad_alloc.
  Actual: it throws a different type.
```
* YinEdgeCase.InvalidAlloc
```
./test_edge_cases.cpp:45: Failure
Expected: pitch_alloc::Yin<double> ya(-1) throws an exception of type std::bad_alloc.
  Actual: it throws a different type.]
```